### PR TITLE
Fix #23/applying current root resolver

### DIFF
--- a/src/Cloudpaths/CloudpathsServiceProvider.php
+++ b/src/Cloudpaths/CloudpathsServiceProvider.php
@@ -35,7 +35,7 @@ class CloudpathsServiceProvider extends ServiceProvider
     {
         $this->app->singleton('Cloudpaths', function ($app) {
             return new Cloudpaths(
-                new Repository($app['config']['cloudpaths'])
+                new Repository($this->app, $app['config']['cloudpaths'])
             );
         });
     }


### PR DESCRIPTION
Add the container dependency to cloudpaths on when binding on service provider.